### PR TITLE
Fix wrong use of form data with time unit

### DIFF
--- a/view_action_form_add.php
+++ b/view_action_form_add.php
@@ -321,7 +321,7 @@ class organizer_add_slots_form extends moodleform
         if ($data['gap'] == 0) {
             $gap = 0;
         } else {
-            $gap = $data['gap']['number'] * $data['gap']['timeunit'];
+            $gap = $data['gap'];
         }
 
         // For new slots.


### PR DESCRIPTION
Under certain conditions of entered time slot details, the handling script may crash. This has perhaps originated from a copy and paste mistake.

See commit message for details.

Just sending this in for the `MOODLE_39_STABLE` branch, because I was looking at the issue in this version; I’d suggest to apply this on all maintained branches.