### PR TITLE
Remove error prone and unnecessary include_once()

### DIFF
--- a/messaging.php
+++ b/messaging.php
@@ -238,8 +238,6 @@ function organizer_prepare_and_send_message($data, $type) {
 
     $sentok = false;
 
-    include_once('lib.php');
-
     switch ($type) {
         case 'edit_notify_student':
             foreach ($data->slots as $slotid) {


### PR DESCRIPTION
./lib.php is included already indirectly via ./locallib.php which in turn is included at the beginning of the file.

And since the path is relative to the directory of the original called script the wrong lib.php may be included.

related to #126 