### PR TITLE
fix Division By Zero Error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -457,7 +457,7 @@ function organizer_update_grades($organizer, $userid = 0) {
                                 $sum += $value->rawgrade;
                             }
                         }
-                        $grade->rawgrade = $sum / $i;
+                        $grade->rawgrade = $i ? $sum / $i : 0;
                 }
             }
             return organizer_grade_item_update($organizer, $grade);


### PR DESCRIPTION
The grade calculation results in 0 / 0, causing an error and preventing the users from being merged successfully.

This issue appears to have already been fixed in Moodle **v5+**. This hotfix applies the corresponding fix to the **v4.5.1** codebase as well.